### PR TITLE
Fix local media processing not working

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,5 +30,7 @@ COPY --from=build /app/web/build .
 COPY ./fixup.sh .
 RUN chmod +x ./fixup.sh && ./fixup.sh && rm ./fixup.sh
 
+COPY ./httpd.conf /etc/httpd.conf
+
 EXPOSE 3000
 CMD ["busybox", "httpd", "-f", "-p", "3000"]

--- a/httpd.conf
+++ b/httpd.conf
@@ -1,0 +1,2 @@
+.mjs:text/javascript
+.wasm:application/wasm


### PR DESCRIPTION
Chrome and Firefox were refusing to load `/_libav/libav-6.5.7.1-remux-cli.wasm.mjs` on my instance because they explicitly demanded `text/javascript` for .mjs files & BusyBox's httpd doesn't, by default, know what Content-Type to set for .mjs and .wasm files

This PR just adds a simple httpd config so the header is set correctly.